### PR TITLE
Allow null datetimes (NoneType)

### DIFF
--- a/tap_bigquery/sync_bigquery.py
+++ b/tap_bigquery/sync_bigquery.py
@@ -197,7 +197,14 @@ def do_sync(config, state, stream):
                            BATCH_TIMESTAMP]:
                     continue
 
-                if prop.format == "date-time":
+                if row[key] is None:
+                    if prop.type[0] != "null":
+                        raise ValueError(
+                            "NULL value not allowed by the schema"
+                        )
+                    else:
+                        record[key] = None
+                elif prop.format == "date-time":
                     if type(row[key]) == str:
                         r = dateutil.parser.parse(row[key])
                     elif type(row[key]) == datetime.date:
@@ -207,24 +214,13 @@ def do_sync(config, state, stream):
                             day=row[key].day)
                     elif type(row[key]) == datetime.datetime:
                         r = row[key]
-                    elif row[key] is None:
-                        if prop.type[0] != "null":
-                            raise ValueError("NULL value not allowed by the schema")
-                        r = None
-                    else:
-                        raise ValueError(
-                            "Record does not match datetime or None type",
-                            "Row = {}, key = {}".format(row, key)
-                        )
-                    record[key] = r.isoformat() if r else None
+                    record[key] = r.isoformat()
                 elif prop.type[1] == "string":
                     record[key] = str(row[key])
-                elif prop.type[1] == "number" and row[key]:
+                elif prop.type[1] == "number":
                     record[key] = Decimal(row[key])
-                elif prop.type[1] == "integer" and row[key]:
+                elif prop.type[1] == "integer":
                     record[key] = int(row[key])
-                elif row[key] is None and prop.type[0] != "null":
-                    raise ValueError("NULL value not allowed by the schema")
                 else:
                     record[key] = row[key]
 

--- a/tap_bigquery/sync_bigquery.py
+++ b/tap_bigquery/sync_bigquery.py
@@ -207,11 +207,14 @@ def do_sync(config, state, stream):
                             day=row[key].day)
                     elif type(row[key]) == datetime.datetime:
                         r = row[key]
+                    elif row[key] is None:
+                        r = row[key]
                     else:
                         raise ValueError(
-                            "Record does not match datetime schema %s" %
-                            row[key])
-                    record[key] = r.isoformat()
+                            "Record does not match datetime or None type",
+                            "Row = {}, key = {}".format(row, key)
+                        )
+                    record[key] = r.isoformat() if r else None
                 elif prop.type[1] == "string":
                     record[key] = str(row[key])
                 elif prop.type[1] == "number" and row[key]:
@@ -222,9 +225,9 @@ def do_sync(config, state, stream):
                     record[key] = row[key]
 
             if LEGACY_TIMESTAMP in properties.keys():
-                record[LEGACY_TIMESTAMP ] = int(round(time.time() * 1000))
+                record[LEGACY_TIMESTAMP] = int(round(time.time() * 1000))
             if EXTRACT_TIMESTAMP in properties.keys():
-                record[EXTRACT_TIMESTAMP ] = extract_tstamp.isoformat()
+                record[EXTRACT_TIMESTAMP] = extract_tstamp.isoformat()
 
             singer.write_record(stream.stream, record)
 

--- a/tap_bigquery/sync_bigquery.py
+++ b/tap_bigquery/sync_bigquery.py
@@ -208,19 +208,23 @@ def do_sync(config, state, stream):
                     elif type(row[key]) == datetime.datetime:
                         r = row[key]
                     elif row[key] is None:
-                        r = row[key]
+                        if prop.type[0] != "null":
+                            raise ValueError("NULL value not allowed by the schema")
+                        r = None
                     else:
                         raise ValueError(
                             "Record does not match datetime or None type",
                             "Row = {}, key = {}".format(row, key)
                         )
                     record[key] = r.isoformat() if r else None
-                elif prop.type[1] == "string":
+                elif prop.type[1] == "string" and row[key]:
                     record[key] = str(row[key])
                 elif prop.type[1] == "number" and row[key]:
                     record[key] = Decimal(row[key])
                 elif prop.type[1] == "integer" and row[key]:
                     record[key] = int(row[key])
+                elif row[key] is None and prop.type[0] != "null":
+                    raise ValueError("NULL value not allowed by the schema")
                 else:
                     record[key] = row[key]
 

--- a/tap_bigquery/sync_bigquery.py
+++ b/tap_bigquery/sync_bigquery.py
@@ -217,7 +217,7 @@ def do_sync(config, state, stream):
                             "Row = {}, key = {}".format(row, key)
                         )
                     record[key] = r.isoformat() if r else None
-                elif prop.type[1] == "string" and row[key]:
+                elif prop.type[1] == "string":
                     record[key] = str(row[key])
                 elif prop.type[1] == "number" and row[key]:
                     record[key] = Decimal(row[key])


### PR DESCRIPTION
In all our BigQuery tables, timestamp columns are nullable. This was causing the tap to fail as a NoneType datetime field was raising this ValueError. This PR allows datetime fields to be None.