### PR TITLE
Update dependencies of setup.py for python 3.11 compatibility 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "attrs==19.3.0",
         "backoff==1.8.0",
         "getschema>=0.1.2",
-        "google-cloud-bigquery==3.2.0",
+        "google-cloud-bigquery>=3.25.0",
         "requests>=2.20.0",
         "simplejson==3.11.1",
         "singer-python>=5.2.0",

--- a/setup.py
+++ b/setup.py
@@ -28,17 +28,16 @@ setup(
     ],
 
     install_requires=[
-        "attrs==19.3.0",
+        "attrs>=21.3.0",
         "backoff==1.8.0",
         "getschema>=0.1.2",
         "google-cloud-bigquery>=3.25.0",
         "requests>=2.20.0",
-        "simplejson==3.11.1",
+        "simplejson>=3.17.0",
         "singer-python>=5.2.0",
         "setuptools>=40.3.0",
         "numpy<2"
     ],
-
     entry_points="""
     [console_scripts]
     tap-bigquery=tap_bigquery:main

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "getschema>=0.1.2",
         "google-cloud-bigquery>=3.25.0",
         "requests>=2.20.0",
-        "simplejson>=3.17.0",
+        "simplejson>=3.11.0",
         "singer-python>=5.2.0",
         "setuptools>=40.3.0",
         "numpy<2"


### PR DESCRIPTION
### Description

This pull request updates the `setup.py` file to use updated dependencies compatible with Python 3.11.

### Changes
- Updated dependency versions in `setup.py` to work with Python 3.11.

### Reason
The current dependencies specified in `setup.py` were not compatible with Python 3.11, causing installation and runtime issues. This update resolves those issues and allows the project to run smoothly with the latest Python version.

Please review the changes and merge if appropriate. Thank you!
